### PR TITLE
fix: highlight browseOnly fields when validation error is clicked

### DIFF
--- a/src/components/inputs/ArrayHierarchyInput.tsx
+++ b/src/components/inputs/ArrayHierarchyInput.tsx
@@ -15,7 +15,7 @@ import {
 } from '@sanity/ui'
 import {useState, useEffect, useCallback} from 'react'
 import type {ArrayFieldProps, ObjectOptions} from 'sanity'
-import {useClient, useFormValue, isVersionId, isDraftId, usePerspective} from 'sanity'
+import {FormField, useClient, useFormValue, isVersionId, isDraftId, usePerspective} from 'sanity'
 
 import {useEmbeddingsRecs} from '../../hooks'
 import NodeTree from '../../static/NodeTree'
@@ -407,19 +407,24 @@ export function ArrayHierarchyInput(props: ArrayHierarchyInputProps) {
       return props.renderDefault(props)
     }
 
+    // Wrap the empty state in `FormField` so the field exposes the same
+    // DOM target Sanity's Validation panel uses for scroll-to-field /
+    // highlight on click. Without this wrapper, clicking a required
+    // browse-only field's validation error has no effect.
     return (
-      <Stack space={2}>
-        <Box paddingY={3}>
-          <Text size={1} weight={'medium'}>
-            {title}
-          </Text>
-        </Box>
+      <FormField
+        title={title}
+        description={props.description}
+        level={props.level}
+        validation={props.validation}
+        __unstable_presence={props.presence}
+      >
         <Card padding={3} radius={2} border>
           <Text muted align="center" size={1}>
             No items
           </Text>
         </Card>
-      </Stack>
+      </FormField>
     )
   }
 

--- a/src/components/inputs/ReferenceHierarchyInput.tsx
+++ b/src/components/inputs/ReferenceHierarchyInput.tsx
@@ -4,7 +4,7 @@ import type {DocumentId} from '@sanity/id-utils'
 import {Grid, Stack, Button, Dialog, Box, Spinner, Text, Flex, Card} from '@sanity/ui'
 import {useState, useEffect, useCallback} from 'react'
 import type {ObjectFieldProps, ObjectOptions, Reference} from 'sanity'
-import {isDraftId, useClient, useFormValue, usePerspective} from 'sanity'
+import {FormField, isDraftId, useClient, useFormValue, usePerspective} from 'sanity'
 
 import {useEmbeddingsRecs} from '../../hooks'
 import NodeTree from '../../static/NodeTree'
@@ -330,19 +330,24 @@ export function ReferenceHierarchyInput(props: HierarchyInput) {
     if (value) {
       return props.renderDefault(props)
     }
+    // Wrap the empty state in `FormField` so the field exposes the same
+    // DOM target Sanity's Validation panel uses for scroll-to-field /
+    // highlight on click. Without this wrapper, clicking a required
+    // browse-only field's validation error has no effect.
     return (
-      <Stack space={2}>
-        <Box paddingY={3}>
-          <Text size={1} weight={'medium'}>
-            {title}
-          </Text>
-        </Box>
+      <FormField
+        title={title}
+        description={props.description}
+        level={props.level}
+        validation={props.validation}
+        __unstable_presence={props.presence}
+      >
         <Card padding={3} radius={2} border>
           <Text muted align="center" size={1}>
             No items
           </Text>
         </Card>
-      </Stack>
+      </FormField>
     )
   }
 


### PR DESCRIPTION
## Problem

When a reference / array hierarchy input is configured with `browseOnly: true` and the value is empty, clicking the field's error in Sanity Studio's Validation panel does **nothing** — no scroll, no focus, no highlight. Every other required field navigates correctly.

### Repro

1. Add a required reference field that uses `branchFilter({…, browseOnly: true})` (or the array equivalent).
2. Save the document with the field empty so the validation marker appears in the side panel.
3. Click the validation entry → the editor does not scroll to / highlight the field.

### Root cause

In `ReferenceHierarchyInput.renderBrowseOnlyPreview()` (and the matching path in `ArrayHierarchyInput`), the empty-`value` branch returns a bare `<Stack>` with the title text and the "No items" card, **skipping `props.renderDefault(props)`**:

```tsx
if (value) {
  return props.renderDefault(props)
}
return (
  <Stack space={2}>
    <Box paddingY={3}><Text …>{title}</Text></Box>
    <Card …><Text …>No items</Text></Card>
  </Stack>
)
```

`renderDefault` is what wraps the field in Sanity's `FormField`, and `FormField` is the DOM target the Validation panel uses to scroll-to / focus a field on click. Without it, the panel has nothing to navigate to and the click silently no-ops. The populated branch and the non-`browseOnly` branch both go through `renderDefault`, which is why only this empty-`browseOnly` case is broken.

## Fix

Wrap the empty-state UI in `FormField` from `sanity`, passing through `title`, `description`, `level`, `validation`, and `presence`. This restores the wrapper Sanity expects without changing the visual: `FormField` already renders the title, so the redundant `<Box><Text>{title}</Text></Box>` is removed. The "No items" card stays put.

The same fix is applied to both `ReferenceHierarchyInput.tsx` and `ArrayHierarchyInput.tsx`, since both share the bug.

```tsx
return (
  <FormField
    title={title}
    description={props.description}
    level={props.level}
    validation={props.validation}
    __unstable_presence={props.presence}
  >
    <Card padding={3} radius={2} border>
      <Text muted align="center" size={1}>No items</Text>
    </Card>
  </FormField>
)
```

## Verification

- Built locally with `yarn build` (clean) and linked into a Studio v5 project.
- Required `branchFilter({…, browseOnly: true})` field: validation error now scrolls to and highlights the field on click, matching every other required field's behaviour.
- Populated state unchanged (still goes through `renderDefault`).
- Visual layout of the empty state unchanged — single title + "No items" card, no double headers.

Happy to adjust if you'd prefer a different shape (e.g. keep the bare `<Stack>` and add `FormField` only as an outer wrapper). Just let me know.